### PR TITLE
Chore: update sputnik version; address portability issues

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "evm"]
-	path = evm
-	url = https://github.com/rust-blockchain/evm
 [submodule "jsontests/res/ethtests"]
 	path = jsontests/res/ethtests
 	url = https://github.com/ethereum/tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,7 +526,8 @@ dependencies = [
 
 [[package]]
 name = "evm"
-version = "0.37.0"
+version = "0.39.1"
+source = "git+https://github.com/0xDuo/evm.git?tag=duo-v1.0.0#75773e512627e471bf828adf96848609fe8b95ce"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -545,7 +546,8 @@ dependencies = [
 
 [[package]]
 name = "evm-core"
-version = "0.37.0"
+version = "0.39.0"
+source = "git+https://github.com/0xDuo/evm.git?tag=duo-v1.0.0#75773e512627e471bf828adf96848609fe8b95ce"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -555,7 +557,8 @@ dependencies = [
 
 [[package]]
 name = "evm-gasometer"
-version = "0.37.0"
+version = "0.39.0"
+source = "git+https://github.com/0xDuo/evm.git?tag=duo-v1.0.0#75773e512627e471bf828adf96848609fe8b95ce"
 dependencies = [
  "environmental",
  "evm-core",
@@ -591,13 +594,12 @@ dependencies = [
 
 [[package]]
 name = "evm-runtime"
-version = "0.37.0"
+version = "0.39.0"
+source = "git+https://github.com/0xDuo/evm.git?tag=duo-v1.0.0#75773e512627e471bf828adf96848609fe8b95ce"
 dependencies = [
  "auto_impl",
  "environmental",
  "evm-core",
- "hex 0.4.0",
- "once_cell",
  "primitive-types",
  "sha3",
 ]

--- a/jsontests/Cargo.toml
+++ b/jsontests/Cargo.toml
@@ -6,12 +6,12 @@ authors = ["Wei Tang <hi@that.world>", "Parity Technologies <admin@parity.io>"]
 description = "SputnikVM - a Portable Blockchain Virtual Machine"
 repository = "https://github.com/sorpaas/rust-evm"
 keywords = ["no_std", "ethereum"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-evm = { path = "../evm", features = ["tracing"] }
-evm-runtime = { path = "../evm/runtime" }
+evm = { git = "https://github.com/0xDuo/evm.git", tag = "duo-v1.0.0", features = ["tracing"] }
+evm-runtime = { git = "https://github.com/0xDuo/evm.git", tag = "duo-v1.0.0" }
 ethereum = { version = "0.14.0", features = ["with-serde"] }
 primitive-types = "0.12"
 regex = "1.8"

--- a/jsontests/src/lib.rs
+++ b/jsontests/src/lib.rs
@@ -4,21 +4,21 @@ pub mod state;
 pub mod vm;
 
 use ethereum::Log;
-use evm_runtime::{ExitReason, ExitError};
+use evm_runtime::{ExitError, ExitReason};
 use primitive_types::{H160, H256};
 use serde::Deserialize;
-use std::{process::Command, path::PathBuf};
+use std::{path::PathBuf, process::Command};
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(tag = "type")]
 pub enum Event {
-  Step {
+	Step {
 		sender: H160,
 		contract: H160,
 		position: usize,
 		opcode: u8,
 		stack: Vec<H256>,
-    #[serde(with = "hex_serde")]
+		#[serde(with = "hex_serde")]
 		memory: Vec<u8>,
 	},
 	SLoad {
@@ -31,28 +31,29 @@ pub enum Event {
 		index: H256,
 		value: H256,
 	},
-  Exit {
-    #[serde(with = "hex_serde")]
-    output: Vec<u8>,
-    exit_reason: u8,
-    logs: Vec<Log>,
-    gas: u64,
-  },
+	Exit {
+		#[serde(with = "hex_serde")]
+		output: Vec<u8>,
+		exit_reason: u8,
+		logs: Vec<Log>,
+		gas: u64,
+	},
 }
 
 impl Event {
-  fn print_compare(steps: &Vec<Event>, events: &Vec<Event>) {
-    println!();
-    // .zip or .iter
-    // for (step, event) in steps.iter().zip(events)
-    // Going to need a big match statements to show differences for each Event type
+	fn print_compare(steps: &Vec<Event>, events: &Vec<Event>) {
+		println!();
+		// .zip or .iter
+		// for (step, event) in steps.iter().zip(events)
+		// Going to need a big match statements to show differences for each Event type
 		for i in 0..std::cmp::min(steps.len(), events.len()) {
 			let step = steps.get(i).unwrap();
 			let event = events.get(i).unwrap();
-      match step { // Show human readable opcode
-        Self::Step { opcode, .. } => println!("\n{} Opcode", format!("{:#x}", opcode)),
-        _ => println!(""),
-      }
+			match step {
+				// Show human readable opcode
+				Self::Step { opcode, .. } => println!("\n{} Opcode", format!("{:#x}", opcode)),
+				_ => println!(""),
+			}
 			if step == event {
 				println!("{:?}", step);
 			} else {
@@ -69,115 +70,133 @@ impl Event {
 			println!("\n-------> Extra RUST EVM:{:?}", events.get(i).unwrap());
 		}
 		println!();
-  }
+	}
 
-  fn copy_static_cafe_values(steps: &mut Vec<Event>, events: &Vec<Event>) {
-    // We copy the stack gas value on the next step after 0x5a opcode
-    let cafe = H256::from_low_u64_be(0xcafe);
-    if steps.len() == events.len() {
-      // let mut found = false;
-      for s in steps.iter_mut().zip(events) {
-        if let Event::Step { stack, .. } = s.0 {
-          if let Event::Step { stack: el_stack, .. } = s.1 {
-            if stack.len() == el_stack.len() {
-              for st in stack.iter_mut().zip(el_stack) {
-                if st.0 == &cafe {
-                  *st.0 = *st.1; // Copy stack value from events
-                }
-              }
-            }
-          }
-        }
-        if let Event::SLoad { value, .. } = s.0 {
-          if let Event::SLoad { value: el_value, .. } = s.1 {
-            if value == &cafe {
-              *value = *el_value;
-            }
-          }
-        }
-        if let Event::SStore { value, .. } = s.0 {
-          if let Event::SStore { value: el_value, .. } = s.1 {
-            if value == &cafe {
-              *value = *el_value;
-            }
-          }
-        }
-      }
-    }
-  }
+	fn copy_static_cafe_values(steps: &mut Vec<Event>, events: &Vec<Event>) {
+		// We copy the stack gas value on the next step after 0x5a opcode
+		let cafe = H256::from_low_u64_be(0xcafe);
+		if steps.len() == events.len() {
+			// let mut found = false;
+			for s in steps.iter_mut().zip(events) {
+				if let Event::Step { stack, .. } = s.0 {
+					if let Event::Step {
+						stack: el_stack, ..
+					} = s.1
+					{
+						if stack.len() == el_stack.len() {
+							for st in stack.iter_mut().zip(el_stack) {
+								if st.0 == &cafe {
+									*st.0 = *st.1; // Copy stack value from events
+								}
+							}
+						}
+					}
+				}
+				if let Event::SLoad { value, .. } = s.0 {
+					if let Event::SLoad {
+						value: el_value, ..
+					} = s.1
+					{
+						if value == &cafe {
+							*value = *el_value;
+						}
+					}
+				}
+				if let Event::SStore { value, .. } = s.0 {
+					if let Event::SStore {
+						value: el_value, ..
+					} = s.1
+					{
+						if value == &cafe {
+							*value = *el_value;
+						}
+					}
+				}
+			}
+		}
+	}
 }
 
 pub struct EventListener {
-  pub events: Vec<Event>,
+	pub events: Vec<Event>,
 }
 
 impl evm::tracing::EventListener for EventListener {
-  fn event(&mut self, event: evm::tracing::Event<'_>) {
-    match event {
-      evt @ _ => println!("Evm Event: {:?}", evt),
-    };
-  }
+	fn event(&mut self, event: evm::tracing::Event<'_>) {
+		match event {
+			evt @ _ => println!("Evm Event: {:?}", evt),
+		};
+	}
 }
 
 impl evm::gasometer::tracing::EventListener for EventListener {
-  fn event(&mut self, event: evm::gasometer::tracing::Event) {
-    match event {
-      evt @ _ => println!("{:?}", evt),
-    };
-  }
+	fn event(&mut self, event: evm::gasometer::tracing::Event) {
+		match event {
+			evt @ _ => println!("{:?}", evt),
+		};
+	}
 }
 
 impl evm_runtime::tracing::EventListener for EventListener {
-  fn event(&mut self, event: evm_runtime::tracing::Event<'_>) {
-    use evm_runtime::tracing::Event as RuntimeEvent;
-    match event {
-      RuntimeEvent::Step { context, opcode, position, stack, memory } =>
-        self.events.push(Event::Step {
-          sender: context.caller.clone(),
-          contract: context.address.clone(),
-          position: position.clone().unwrap(),
-          opcode: opcode.0,
-          stack: stack.data().clone(),
-          memory: memory.data().clone(),
-        }),
-        RuntimeEvent::SLoad { address, index, value } =>
-				self.events.push(Event::SLoad {
-					address: address.clone(),
-					index: index.clone(),
-					value: value.clone(),
-				}),
-        RuntimeEvent::SStore { address, index, value } =>
-				self.events.push(Event::SStore {
-					address: address.clone(),
-					index: index.clone(),
-					value: value.clone(),
-				}),
-      _ => (),
-    };
-  }
+	fn event(&mut self, event: evm_runtime::tracing::Event<'_>) {
+		use evm_runtime::tracing::Event as RuntimeEvent;
+		match event {
+			RuntimeEvent::Step {
+				context,
+				opcode,
+				position,
+				stack,
+				memory,
+			} => self.events.push(Event::Step {
+				sender: context.caller.clone(),
+				contract: context.address.clone(),
+				position: position.clone().unwrap(),
+				opcode: opcode.0,
+				stack: stack.data().clone(),
+				memory: memory.data().clone(),
+			}),
+			RuntimeEvent::SLoad {
+				address,
+				index,
+				value,
+			} => self.events.push(Event::SLoad {
+				address: address.clone(),
+				index: index.clone(),
+				value: value.clone(),
+			}),
+			RuntimeEvent::SStore {
+				address,
+				index,
+				value,
+			} => self.events.push(Event::SStore {
+				address: address.clone(),
+				index: index.clone(),
+				value: value.clone(),
+			}),
+			_ => (),
+		};
+	}
 }
 
 pub fn exit_reason_to_u8(exit_reason: &ExitReason) -> u8 {
-  match exit_reason {
-    evm_runtime::ExitReason::Succeed(s) => s.clone() as u8,
-    evm_runtime::ExitReason::Revert(_) => 0x10,
-    evm_runtime::ExitReason::Fatal(_) => 0x20,
-    evm_runtime::ExitReason::Error(e) => {
-      match e {
-        ExitError::StackUnderflow => 0x30,
-        ExitError::StackOverflow => 0x31,
-        ExitError::InvalidJump => 0x32,
-        ExitError::InvalidRange => 0x33,
-        ExitError::DesignatedInvalid => 0x34,
-        ExitError::CallTooDeep => 0x35,
-        ExitError::OutOfOffset => 0x38,
-        ExitError::OutOfGas => 0x39,
-        ExitError::Other(_) => 0x3d,
-        ExitError::InvalidCode(_) => 0x3f,
-        _ => 0x30,
-      }
-    },
-  }
+	match exit_reason {
+		evm_runtime::ExitReason::Succeed(s) => s.clone() as u8,
+		evm_runtime::ExitReason::Revert(_) => 0x10,
+		evm_runtime::ExitReason::Fatal(_) => 0x20,
+		evm_runtime::ExitReason::Error(e) => match e {
+			ExitError::StackUnderflow => 0x30,
+			ExitError::StackOverflow => 0x31,
+			ExitError::InvalidJump => 0x32,
+			ExitError::InvalidRange => 0x33,
+			ExitError::DesignatedInvalid => 0x34,
+			ExitError::CallTooDeep => 0x35,
+			ExitError::OutOfOffset => 0x38,
+			ExitError::OutOfGas => 0x39,
+			ExitError::Other(_) => 0x3d,
+			ExitError::InvalidCode(_) => 0x3f,
+			_ => 0x30,
+		},
+	}
 }
 
 pub fn run_move_test() -> anyhow::Result<Vec<Event>> {
@@ -196,37 +215,55 @@ pub fn run_move_test() -> anyhow::Result<Vec<Event>> {
 	let output = output.replace("[debug] ", "");
 	let output = output.replace("\"", "");
 
-	let output = regex::Regex::new(r"INCLUDING.*").unwrap().replace_all(&output, "");
-	let output = regex::Regex::new(r"BUILDING.*").unwrap().replace(&output, "");
-	let output = regex::Regex::new(r"Running.*").unwrap().replace(&output, "");
-	let output = regex::Regex::new(r"\[ PASS.*").unwrap().replace(&output, "");
-	let output = regex::Regex::new(r"Test.*").unwrap().replace_all(&output, "");
+	let output = regex::Regex::new(r"INCLUDING.*")
+		.unwrap()
+		.replace_all(&output, "");
+	let output = regex::Regex::new(r"BUILDING.*")
+		.unwrap()
+		.replace(&output, "");
+	let output = regex::Regex::new(r"Running.*")
+		.unwrap()
+		.replace(&output, "");
+	let output = regex::Regex::new(r"\[ PASS.*")
+		.unwrap()
+		.replace(&output, "");
+	let output = regex::Regex::new(r"Test.*")
+		.unwrap()
+		.replace_all(&output, "");
 	let output = regex::Regex::new(r"\{.*").unwrap().replace_all(&output, "");
 	let output = regex::Regex::new(r"\}.*").unwrap().replace_all(&output, "");
-	let output = regex::Regex::new(r".*Result.*").unwrap().replace(&output, "");
+	let output = regex::Regex::new(r".*Result.*")
+		.unwrap()
+		.replace(&output, "");
 
-  let output = regex::Regex::new(r"\[ FAIL.*").unwrap().replace(&output, "");
-  let output = regex::Regex::new(r"Failures.*").unwrap().replace(&output, "");
-  let output = regex::Regex::new(r"┌.*").unwrap().replace(&output, "");
-  let output = regex::Regex::new(r"│.*").unwrap().replace_all(&output, "");
-  let output = regex::Regex::new(r"└.*").unwrap().replace(&output, "");
-  let output = regex::Regex::new(r".*Error.*").unwrap().replace(&output, "");
+	let output = regex::Regex::new(r"\[ FAIL.*")
+		.unwrap()
+		.replace(&output, "");
+	let output = regex::Regex::new(r"Failures.*")
+		.unwrap()
+		.replace(&output, "");
+	let output = regex::Regex::new(r"┌.*").unwrap().replace(&output, "");
+	let output = regex::Regex::new(r"│.*").unwrap().replace_all(&output, "");
+	let output = regex::Regex::new(r"└.*").unwrap().replace(&output, "");
+	let output = regex::Regex::new(r".*Error.*")
+		.unwrap()
+		.replace(&output, "");
 	// println!("{}", output);
 	serde_yaml::from_str(&output).map_err(anyhow::Error::from)
 }
 
 pub fn get_repository_root() -> anyhow::Result<PathBuf> {
-  let output = Command::new("git")
-        .args(["rev-parse", "--show-toplevel"])
-        .output()?;
+	let output = Command::new("git")
+		.args(["rev-parse", "--show-toplevel"])
+		.output()?;
 
-  if !output.status.success() {
-    return Err(anyhow::Error::msg(
-        "Command `git rev-parse --show-toplevel` failed",
-    ));
-  }
+	if !output.status.success() {
+		return Err(anyhow::Error::msg(
+			"Command `git rev-parse --show-toplevel` failed",
+		));
+	}
 
-  let output = String::from_utf8(output.stdout)?;
-  let path = PathBuf::try_from(output.trim())?;
-  Ok(path)
+	let output = String::from_utf8(output.stdout)?;
+	let path = PathBuf::try_from(output.trim())?;
+	Ok(path)
 }

--- a/jsontests/src/lib.rs
+++ b/jsontests/src/lib.rs
@@ -7,7 +7,7 @@ use ethereum::Log;
 use evm_runtime::{ExitReason, ExitError};
 use primitive_types::{H160, H256};
 use serde::Deserialize;
-use std::process::Command;
+use std::{process::Command, path::PathBuf};
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(tag = "type")]
@@ -182,8 +182,8 @@ pub fn exit_reason_to_u8(exit_reason: &ExitReason) -> u8 {
 
 pub fn run_move_test() -> anyhow::Result<Vec<Event>> {
 	// aptos move test --bytecode-version 6 -i 10000000 -f steps
-	let command_output = Command::new("aptos")
-		.current_dir("/Users/bulent/Desktop/Blockchain/EVM/devm")
+	let command_output = Command::new("/data_disk/duo/aptos-core/target/release/aptos")
+		.current_dir("/data_disk/duo/devm")
 		.arg("move")
 		.arg("test")
 		.args(["--bytecode-version", "6"])
@@ -213,4 +213,20 @@ pub fn run_move_test() -> anyhow::Result<Vec<Event>> {
   let output = regex::Regex::new(r".*Error.*").unwrap().replace(&output, "");
 	// println!("{}", output);
 	serde_yaml::from_str(&output).map_err(anyhow::Error::from)
+}
+
+pub fn get_repository_root() -> anyhow::Result<PathBuf> {
+  let output = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()?;
+
+  if !output.status.success() {
+    return Err(anyhow::Error::msg(
+        "Command `git rev-parse --show-toplevel` failed",
+    ));
+  }
+
+  let output = String::from_utf8(output.stdout)?;
+  let path = PathBuf::try_from(output.trim())?;
+  Ok(path)
 }

--- a/jsontests/src/lib.rs
+++ b/jsontests/src/lib.rs
@@ -7,7 +7,10 @@ use ethereum::Log;
 use evm_runtime::{ExitError, ExitReason};
 use primitive_types::{H160, H256};
 use serde::Deserialize;
-use std::{path::PathBuf, process::Command};
+use std::{
+	path::{Path, PathBuf},
+	process::Command,
+};
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(tag = "type")]
@@ -199,10 +202,12 @@ pub fn exit_reason_to_u8(exit_reason: &ExitReason) -> u8 {
 	}
 }
 
-pub fn run_move_test() -> anyhow::Result<Vec<Event>> {
+pub fn run_move_test(devm_path: &Path) -> anyhow::Result<Vec<Event>> {
+	let aptos_path_env = std::env::var("APTOS_PATH");
+	let aptos_program = aptos_path_env.as_deref().unwrap_or("aptos");
 	// aptos move test --bytecode-version 6 -i 10000000 -f steps
-	let command_output = Command::new("/data_disk/duo/aptos-core/target/release/aptos")
-		.current_dir("/data_disk/duo/devm")
+	let command_output = Command::new(aptos_program)
+		.current_dir(devm_path)
 		.arg("move")
 		.arg("test")
 		.args(["--bytecode-version", "6"])

--- a/jsontests/src/main.rs
+++ b/jsontests/src/main.rs
@@ -29,6 +29,11 @@ fn main() {
 		.get_matches();
 
 	let repository_root = evm_jsontests::get_repository_root().unwrap();
+	// Assumes `devm` is located in the folder next to this repository root
+	let devm_path = repository_root
+		.parent()
+		.unwrap_or(&repository_root)
+		.join("devm");
 
 	if let Some(matches) = matches.subcommand_matches("vm") {
 		for file_name in matches.values_of("FILE").unwrap() {
@@ -39,7 +44,7 @@ fn main() {
 				.expect("Parse test cases failed");
 
 			for (name, test) in coll {
-				vmtests::test(&name, test, &repository_root);
+				vmtests::test(&name, test, &devm_path);
 			}
 		}
 	}
@@ -53,7 +58,7 @@ fn main() {
 				.expect("Parse test cases failed");
 
 			for (name, test) in coll {
-				statetests::test(&name, test, &repository_root);
+				statetests::test(&name, test, &devm_path);
 			}
 		}
 	}

--- a/jsontests/src/main.rs
+++ b/jsontests/src/main.rs
@@ -28,6 +28,8 @@ fn main() {
 		)
 		.get_matches();
 
+	let repository_root = evm_jsontests::get_repository_root().unwrap();
+
 	if let Some(matches) = matches.subcommand_matches("vm") {
 		for file_name in matches.values_of("FILE").unwrap() {
 			let file = File::open(file_name).expect("Open file failed");
@@ -37,7 +39,7 @@ fn main() {
 				.expect("Parse test cases failed");
 
 			for (name, test) in coll {
-				vmtests::test(&name, test);
+				vmtests::test(&name, test, &repository_root);
 			}
 		}
 	}
@@ -51,7 +53,7 @@ fn main() {
 				.expect("Parse test cases failed");
 
 			for (name, test) in coll {
-				statetests::test(&name, test);
+				statetests::test(&name, test, &repository_root);
 			}
 		}
 	}

--- a/jsontests/src/state.rs
+++ b/jsontests/src/state.rs
@@ -1,6 +1,6 @@
-use crate::Event;
 use crate::exit_reason_to_u8;
 use crate::utils::*;
+use crate::Event;
 use crate::EventListener;
 use ethjson::maybe::MaybeEmpty;
 use ethjson::spec::ForkSpec;
@@ -83,21 +83,20 @@ impl Test {
 
 		let block_randomness = if spec.is_eth2() {
 			self.0.env.random.map(|r| {
-                // Convert between U256 and H256. U256 is in little-endian but since H256 is just
-                // a string-like byte array, it's big endian (MSB is the first element of the array).
-                //
-                // Byte order here is important because this opcode has the same value as DIFFICULTY
-                // (0x44), and so for older forks of Ethereum, the threshold value of 2^64 is used to
-                // distinguish between the two: if it's below, the value corresponds to the DIFFICULTY
-                // opcode, otherwise to the PREVRANDAO opcode.
-                let mut buf = [0u8; 32];
-                r.0.to_big_endian(&mut buf);
-                H256(buf)
-            })
+				// Convert between U256 and H256. U256 is in little-endian but since H256 is just
+				// a string-like byte array, it's big endian (MSB is the first element of the array).
+				//
+				// Byte order here is important because this opcode has the same value as DIFFICULTY
+				// (0x44), and so for older forks of Ethereum, the threshold value of 2^64 is used to
+				// distinguish between the two: if it's below, the value corresponds to the DIFFICULTY
+				// opcode, otherwise to the PREVRANDAO opcode.
+				let mut buf = [0u8; 32];
+				r.0.to_big_endian(&mut buf);
+				H256(buf)
+			})
 		} else {
 			None
 		};
-
 
 		Some(MemoryVicinity {
 			gas_price,
@@ -228,31 +227,51 @@ pub fn generate_move_test_file(test: &Test, transaction: &Transaction, repositor
 	content.push_str("#[test_only]\n");
 	content.push_str("module devm::steps {\n");
 	content.push_str("  #[test(owner = @devm)]\n");
-  content.push_str("  fun test(owner: signer) {\n");
-  content.push_str("    aptos_framework::account::create_account_for_test(std::signer::address_of(&owner));\n");
-  content.push_str("    devm::evm::initialize(&owner);\n");
+	content.push_str("  fun test(owner: signer) {\n");
+	content.push_str(
+		"    aptos_framework::account::create_account_for_test(std::signer::address_of(&owner));\n",
+	);
+	content.push_str("    devm::evm::initialize(&owner);\n");
 	content.push_str("    let changes = &mut devm::state::new_changes();\n");
-	content.push_str(&format!("    devm::state::set_basic(changes, @{:?}, {}, {});\n", test.unwrap_caller(), 0, 1_000_000_000));
+	content.push_str(&format!(
+		"    devm::state::set_basic(changes, @{:?}, {}, {});\n",
+		test.unwrap_caller(),
+		0,
+		1_000_000_000
+	));
 	for (address, account) in test.unwrap_to_pre_state().into_iter() {
-		content.push_str(&format!("    devm::state::set_basic(changes, @{:?}, {}, {});\n", address, account.nonce, account.balance));
+		content.push_str(&format!(
+			"    devm::state::set_basic(changes, @{:?}, {}, {});\n",
+			address, account.nonce, account.balance
+		));
 		if account.code.len() > 0 {
-			content.push_str(&format!("    devm::state::set_code(changes, @{:?}, x\"{}\");\n", address, hex::encode(account.code)));
+			content.push_str(&format!(
+				"    devm::state::set_code(changes, @{:?}, x\"{}\");\n",
+				address,
+				hex::encode(account.code)
+			));
 		}
 		if account.storage.len() > 0 {
 			for (index, value) in account.storage.iter() {
-				content.push_str(&format!("    devm::state::set_storage(changes, @{:?}, {:?}, {:?});\n", address, index, value));
+				content.push_str(&format!(
+					"    devm::state::set_storage(changes, @{:?}, {:?}, {:?});\n",
+					address, index, value
+				));
 			}
 		}
 	}
 	content.push_str(&format!("    devm::state::apply(changes);\n\n"));
-	if let MaybeEmpty::Some(to) = transaction.to { // Regular transaction
+	if let MaybeEmpty::Some(to) = transaction.to {
+		// Regular transaction
 		content.push_str(&format!("    let params = devm::evm::new_run_params(@{:?}, @{:?}, devm::state::get_code(changes, @{:?}), {}, x\"{}\", {:#x}, {:#x});\n", test.unwrap_caller(), to.0, to.0, transaction.value.0, hex::encode(transaction.data.to_vec()), transaction.gas_limit.0.as_u64() - GAS_TRANSACTION, transaction.gas_price.0.as_u64()));
 		content.push_str("    let (output, exit_reason, logs, gas) = devm::evm::run(params, &mut devm::state::new_changes(), true);\n");
 		content.push_str("    devm::evm::print_output(output, exit_reason, logs, gas);\n");
-	} else { // Create transaction
+	} else {
+		// Create transaction
 		content.push_str(&format!("    let params = devm::evm::new_run_params(@{:?}, @0x6295ee1b4f6dd65047762f924ecd367c17eabf8f, x\"{}\", {}, x\"\", {:#x}, {:#x});\n", test.unwrap_caller(), hex::encode(transaction.data.to_vec()), transaction.value.0, transaction.gas_limit.0.as_u64() - GAS_CREATE - GAS_TRANSACTION, transaction.gas_price.0.as_u64()));
 		content.push_str("    let (_, exit_reason, logs, gas) = devm::evm::run(params, &mut devm::state::new_changes(), true);\n");
-		content.push_str("    devm::evm::print_output(vector[], exit_reason, logs, gas);\n"); // Create doesn't print the output
+		content.push_str("    devm::evm::print_output(vector[], exit_reason, logs, gas);\n");
+		// Create doesn't print the output
 	}
 	content.push_str("  }\n");
 	content.push_str("}\n");
@@ -261,7 +280,8 @@ pub fn generate_move_test_file(test: &Test, transaction: &Transaction, repositor
 	let file_path = repository_root
 		.parent()
 		.unwrap_or(&repository_root)
-		.join("devm").join("tests")
+		.join("devm")
+		.join("tests")
 		.join("steps.move");
 	write(file_path, content).expect("Unable to write the steps test file");
 }
@@ -350,35 +370,35 @@ fn test_run(name: &str, test: Test, repository_root: &Path) {
 					.collect();
 
 				let mut el = EventListener { events: vec![] };
-				let Transaction { to, value, ..} = transaction;
+				let Transaction { to, value, .. } = transaction;
 				let reason = using(&mut el, || {
-				// let mut el2 = EventListener { events: vec![] };
-				// evm::tracing::using(&mut el2, || {
-				// let mut el2 = EventListener { events: vec![] };
-				// evm::gasometer::tracing::using(&mut el2, || {
-				match to {
-					ethjson::maybe::MaybeEmpty::Some(to) => {
-						let data = data;
-						let value = value.into();
+					// let mut el2 = EventListener { events: vec![] };
+					// evm::tracing::using(&mut el2, || {
+					// let mut el2 = EventListener { events: vec![] };
+					// evm::gasometer::tracing::using(&mut el2, || {
+					match to {
+						ethjson::maybe::MaybeEmpty::Some(to) => {
+							let data = data;
+							let value = value.into();
 
-						executor.transact_call(
-							caller,
-							to.into(),
-							value,
-							data,
-							gas_limit,
-							access_list,
-						)
-					}
-					ethjson::maybe::MaybeEmpty::None => {
-						let code = data;
-						let value = value.into();
+							executor.transact_call(
+								caller,
+								to.into(),
+								value,
+								data,
+								gas_limit,
+								access_list,
+							)
+						}
+						ethjson::maybe::MaybeEmpty::None => {
+							let code = data;
+							let value = value.into();
 
-						executor.transact_create(caller, value, code, gas_limit, access_list)
+							executor.transact_create(caller, value, code, gas_limit, access_list)
+						}
 					}
-				}
-				// })
-				// })
+					// })
+					// })
 				});
 
 				let actual_fee = executor.fee(vicinity.gas_price);
@@ -405,9 +425,17 @@ fn test_run(name: &str, test: Test, repository_root: &Path) {
 				let logs: Vec<_> = logs.into_iter().collect();
 
 				backend.apply(values, logs.clone(), delete_empty);
-				el.events.push(crate::Event::Exit { output: reason.1, exit_reason: exit_reason_to_u8(&reason.0), logs, gas: gas_limit - used_gas });
+				el.events.push(crate::Event::Exit {
+					output: reason.1,
+					exit_reason: exit_reason_to_u8(&reason.0),
+					logs,
+					gas: gas_limit - used_gas,
+				});
 
-				let mut steps = steps.unwrap_or_else(|_| {println!("There's a problem with dEVM"); vec![]});
+				let mut steps = steps.unwrap_or_else(|_| {
+					println!("There's a problem with dEVM");
+					vec![]
+				});
 				Event::copy_static_cafe_values(&mut steps, &el.events);
 
 				if steps == el.events {

--- a/jsontests/src/vm.rs
+++ b/jsontests/src/vm.rs
@@ -76,7 +76,7 @@ impl Test {
 	}
 }
 
-pub fn generate_move_test_file(test: &Test, repository_root: &Path) {
+pub fn generate_move_test_file(test: &Test, devm_path: &Path) {
 	let mut content = String::from("");
 	content.push_str("#[test_only]\n");
 	content.push_str("module devm::steps {\n");
@@ -120,17 +120,11 @@ pub fn generate_move_test_file(test: &Test, repository_root: &Path) {
 	content.push_str("  }\n");
 	content.push_str("}\n");
 
-	// Assumes `devm` is located in the folder next to this repository root
-	let file_path = repository_root
-		.parent()
-		.unwrap_or(&repository_root)
-		.join("devm")
-		.join("tests")
-		.join("steps.move");
+	let file_path = devm_path.join("tests").join("steps.move");
 	write(file_path, content).expect("Unable to write the steps test file");
 }
 
-pub fn test(name: &str, test: Test, repository_root: &Path) {
+pub fn test(name: &str, test: Test, devm_path: &Path) {
 	print!("Running test {} ... ", name);
 	flush();
 
@@ -149,8 +143,8 @@ pub fn test(name: &str, test: Test, repository_root: &Path) {
 	let mut runtime =
 		evm::Runtime::new(code, data, context, config.stack_limit, config.memory_limit);
 
-	generate_move_test_file(&test, repository_root);
-	let steps = crate::run_move_test();
+	generate_move_test_file(&test, devm_path);
+	let steps = crate::run_move_test(devm_path);
 
 	let mut el = EventListener { events: vec![] };
 	let (reason, output) = using(&mut el, || {

--- a/jsontests/tests/state.rs
+++ b/jsontests/tests/state.rs
@@ -10,6 +10,8 @@ pub fn run(dir: &str) {
 	let mut dest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
 	dest.push(dir);
 
+	let repository_root = evm_jsontests::get_repository_root().unwrap();
+
 	for entry in fs::read_dir(dest).unwrap() {
 		let entry = entry.unwrap();
 		if let Some(s) = entry.file_name().to_str() {
@@ -27,7 +29,7 @@ pub fn run(dir: &str) {
 			serde_json::from_reader(reader).expect("Parse test cases failed");
 
 		for (name, test) in coll {
-			statetests::test(&name, test);
+			statetests::test(&name, test, &repository_root);
 		}
 	}
 }

--- a/jsontests/tests/state.rs
+++ b/jsontests/tests/state.rs
@@ -11,6 +11,11 @@ pub fn run(dir: &str) {
 	dest.push(dir);
 
 	let repository_root = evm_jsontests::get_repository_root().unwrap();
+	// Assumes `devm` is located in the folder next to this repository root
+	let devm_path = repository_root
+		.parent()
+		.unwrap_or(&repository_root)
+		.join("devm");
 
 	for entry in fs::read_dir(dest).unwrap() {
 		let entry = entry.unwrap();
@@ -29,7 +34,7 @@ pub fn run(dir: &str) {
 			serde_json::from_reader(reader).expect("Parse test cases failed");
 
 		for (name, test) in coll {
-			statetests::test(&name, test, &repository_root);
+			statetests::test(&name, test, &devm_path);
 		}
 	}
 }

--- a/jsontests/tests/vm.rs
+++ b/jsontests/tests/vm.rs
@@ -11,6 +11,11 @@ pub fn run(dir: &str) {
 	dest.push(dir);
 
 	let repository_root = evm_jsontests::get_repository_root().unwrap();
+	// Assumes `devm` is located in the folder next to this repository root
+	let devm_path = repository_root
+		.parent()
+		.unwrap_or(&repository_root)
+		.join("devm");
 
 	for entry in fs::read_dir(dest).unwrap() {
 		let entry = entry.unwrap();
@@ -23,7 +28,7 @@ pub fn run(dir: &str) {
 			.expect("Parse test cases failed");
 
 		for (name, test) in coll {
-			vmtests::test(&name, test, &repository_root);
+			vmtests::test(&name, test, &devm_path);
 		}
 	}
 }

--- a/jsontests/tests/vm.rs
+++ b/jsontests/tests/vm.rs
@@ -10,6 +10,8 @@ pub fn run(dir: &str) {
 	let mut dest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
 	dest.push(dir);
 
+	let repository_root = evm_jsontests::get_repository_root().unwrap();
+
 	for entry in fs::read_dir(dest).unwrap() {
 		let entry = entry.unwrap();
 		let path = entry.path();
@@ -21,7 +23,7 @@ pub fn run(dir: &str) {
 			.expect("Parse test cases failed");
 
 		for (name, test) in coll {
-			vmtests::test(&name, test);
+			vmtests::test(&name, test, &repository_root);
 		}
 	}
 }


### PR DESCRIPTION
This is a large-ish PR, but should be pretty easy to review if you only look at the first commit. The second commit is just the result of running `cargo fmt` to make the formatting consistent.

The first commit changes the sputnik version to the Duo fork and replaces the hard-coded absolute path defining where to write the Move test file with a path relative to the repository root.