### PR TITLE
Chore: compile-time feature for early exit from state tests

### DIFF
--- a/jsontests/Cargo.toml
+++ b/jsontests/Cargo.toml
@@ -29,3 +29,7 @@ sha3 = "0.10"
 parity-bytes = "0.1"
 env_logger = "0.9"
 lazy_static = "1.4.0"
+
+[features]
+default = []
+early_exit = []

--- a/jsontests/src/lib.rs
+++ b/jsontests/src/lib.rs
@@ -13,6 +13,12 @@ use std::{
 	process::Command,
 };
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TestStatus {
+	Passed,
+	Failed,
+}
+
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(tag = "type")]
 pub enum Event {

--- a/jsontests/tests/state.rs
+++ b/jsontests/tests/state.rs
@@ -1,4 +1,4 @@
-use evm_jsontests::state as statetests;
+use evm_jsontests::{state as statetests, TestStatus};
 use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::BufReader;
@@ -40,7 +40,8 @@ pub fn run(dir: &str) {
 			serde_json::from_reader(reader).expect("Parse test cases failed");
 
 		for (name, test) in coll {
-			statetests::test(&name, test, &devm_path);
+			let result = statetests::test(&name, test, &devm_path);
+			assert_eq!(result, TestStatus::Passed);
 		}
 	}
 }


### PR DESCRIPTION
This is a small quality of life improvement for me. It allows passing `--features early_exit` when running the tests to have it fail on the first test that has different tracing steps. This is nice for me when I am looking at a specific test and I want to know if my changes helped or not. This change does not impact the running of the tests normally (all tests run with the tracing steps reported), only when the `early_exit` feature is given will the test bail out on the first difference.