### PR TITLE
Fix(tracing): Set exit gas equal to zero if out of gas

### DIFF
--- a/jsontests/src/lib.rs
+++ b/jsontests/src/lib.rs
@@ -176,7 +176,8 @@ impl evm::tracing::EventListener for EventListener {
 				// Only save the current step if we didn't run out of gas;
 				// devm does not print the last step if it ran out of gas.
 				if let ExitReason::Error(ExitError::OutOfGas) = reason {
-					()
+					// If exit due to out of gas then there is no gas left.
+					self.intermediate_exit.gas = 0;
 				} else {
 					self.save_current_step();
 				}


### PR DESCRIPTION
The final gas value set by the `RecordRefund` is incorrect in the case of out of gas. I think because the `snapshot` in SputnikVM is only updated if the gas is successfully deducted.

In this PR we manually set the exit gas to be 0 in the case of out of gas.