### PR TITLE
Fix: set gas limit correctly for opcode 0xfe

### DIFF
--- a/jsontests/src/lib.rs
+++ b/jsontests/src/lib.rs
@@ -120,6 +120,12 @@ pub struct EventListener {
 impl EventListener {
 	fn save_current_step(&mut self) {
 		if !self.current_step_consumed {
+			// By definition `OpCode::INVALID` consumes all the remaining gas,
+			// but for reasons related to the details of how Sputnik handles this,
+			// it does not properly capture the gas limit. So we correct it here.
+			if self.current_step.opcode == 0xfe {
+				self.current_step.gas_limit = self.current_step.gas_cost;
+			}
 			self.events.push(crate::Event::Step {
 				sender: self.current_step.sender,
 				contract: self.current_step.contract,

--- a/jsontests/src/lib.rs
+++ b/jsontests/src/lib.rs
@@ -419,7 +419,8 @@ impl ExitBehavior {
 		// This manual intervention is needed only because spunik events may or may not
 		// be emitted depending on where exactly the error happens.
 		let (set_remaining_gas_to_zero, save_current_step, subtract_cost) = match reason {
-			ExitReason::Error(ExitError::OutOfOffset) => (true, true, false),
+			ExitReason::Error(ExitError::OutOfOffset)
+			| ExitReason::Error(ExitError::InvalidCode(evm::Opcode::INVALID)) => (true, true, false),
 			ExitReason::Error(ExitError::OutOfGas) => (true, false, false),
 			ExitReason::Error(ExitError::StackUnderflow) => (false, true, true),
 			_ => (false, true, false),


### PR DESCRIPTION
Needed for `CreateAddressWarmAfterFail:Shanghai:19` in `st_create` to pass.