### PR TITLE
Feat: allow gas values to be ignored sometime in comparing steps

### DIFF
--- a/jsontests/src/tracing.rs
+++ b/jsontests/src/tracing.rs
@@ -1,3 +1,4 @@
+use serde::Deserialize;
 use std::{cell::RefCell, ptr::NonNull, rc::Rc};
 
 /// Capture all events from `SputnikVM` emitted from within the given closure using the given listener.
@@ -18,6 +19,46 @@ where
 			evm::tracing::using(&mut evm_listener, f)
 		})
 	})
+}
+
+/// This is a newtype over `u64` which allows the value to be missing.
+/// The reason for this type is because comparing devm and Sputnik
+/// gas values is not easy in some error cases. In such cases it does not
+/// really matter what gas values are present on the step where the error
+/// occurred because it is not observable to a user (the observable is how
+/// much gas remains on the next step). With this type we can avoid checking
+/// for gas equality by setting the value as `None`.
+#[derive(Clone, Copy, Debug, Deserialize)]
+#[serde(from = "u64")]
+pub struct TracingGas {
+	pub value: Option<u64>,
+}
+
+impl From<u64> for TracingGas {
+	fn from(value: u64) -> Self {
+		Self { value: Some(value) }
+	}
+}
+
+impl PartialEq for TracingGas {
+	fn eq(&self, other: &Self) -> bool {
+		match (self.value, other.value) {
+			(None, None) | (None, Some(_)) | (Some(_), None) => true,
+			(Some(x), Some(y)) => x == y,
+		}
+	}
+}
+
+impl Default for TracingGas {
+	fn default() -> Self {
+		Self { value: Some(0) }
+	}
+}
+
+impl std::ops::SubAssign for TracingGas {
+	fn sub_assign(&mut self, rhs: Self) {
+		self.value.as_mut().and_then(|x| rhs.value.map(|y| *x -= y));
+	}
 }
 
 /// This structure is intentionally private to this module as it is memory unsafe (contains a raw pointer).
@@ -72,4 +113,47 @@ impl<T: evm::tracing::EventListener> evm::tracing::EventListener for SharedMutab
 			self.pointer.borrow_mut().as_mut().event(event);
 		}
 	}
+}
+
+#[test]
+fn test_gas_partial_eq() {
+	let big: TracingGas = 10.into();
+	let small: TracingGas = 2.into();
+	let missing = TracingGas { value: None };
+
+	// Two some values are equal iff the inner values are equal
+	assert_eq!(big, big);
+	assert_eq!(small, small);
+	assert_ne!(big, small);
+
+	// None values are equal to anything
+	assert_eq!(big, missing);
+	assert_eq!(small, missing);
+	assert_eq!(missing, missing);
+}
+
+#[test]
+fn test_gas_sub_assign() {
+	let big: TracingGas = 10.into();
+	let small: TracingGas = 2.into();
+	let missing = TracingGas { value: None };
+
+	// None minus anything is still None
+	let mut x = missing;
+	x -= big;
+	assert_eq!(x.value, missing.value);
+	x -= small;
+	assert_eq!(x.value, missing.value);
+	x -= missing;
+	assert_eq!(x.value, missing.value);
+
+	// Anything minus None does not change the value
+	let mut x = big;
+	x -= missing;
+	assert_eq!(x.value, big.value);
+
+	// Subtracting two present values does the subtraction
+	let mut x = big;
+	x -= small;
+	assert_eq!(x.value, Some(big.value.unwrap() - small.value.unwrap()));
 }


### PR DESCRIPTION
There are some errors where the step is traced by both devm and sputnik but it is hard to compare the gas values. In these cases it is not very important to exactly match the gas values in the tracing because they are not observable in real transactions. What is observable is the remaining gas in the step following the error, and that will still be checked even after the change in this PR. The goal of this PR is to allow us to ignore the gas values of the step where an error occurs since again it is hard to make them match exactly and ultimately it does not matter if they match or not. This is accomplished by introducing a newtype with a custom `PartialEq` implementation for gas values. This type allows the value to be missing and in that case it is always assumed to be equal to any other gas value.