### PR TITLE
Fix: Do not log events where gas has already run out

### DIFF
--- a/jsontests/src/tracing.rs
+++ b/jsontests/src/tracing.rs
@@ -49,6 +49,14 @@ impl PartialEq for TracingGas {
 	}
 }
 
+impl PartialOrd for TracingGas {
+	fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+		self.value
+			.as_ref()
+			.and_then(|x| other.value.as_ref().and_then(|y| x.partial_cmp(y)))
+	}
+}
+
 impl Default for TracingGas {
 	fn default() -> Self {
 		Self { value: Some(0) }


### PR DESCRIPTION
This PR prevents steps where `gas_limit` is less than `gas_cost` from being logged. I also drop the depth constraint off the ExitBehavior case where the last event is thrown out if it wasn't supposed to be logged.

These changes help more of the `st_call_create_call_code` tests pass.